### PR TITLE
Add datacontracts test command

### DIFF
--- a/src/entropy_data_cli/client.py
+++ b/src/entropy_data_cli/client.py
@@ -121,6 +121,16 @@ class EntropyDataClient:
         _raise_for_status(response)
         return response.headers.get(RESPONSE_HEADER_LOCATION_HTML)
 
+    def post_action_json(self, path: str, resource_id: str, action: str, params: dict | None = None,
+                         timeout: int = REQUEST_TIMEOUT) -> dict:
+        """POST /api/{path}/{id}/{action} with query params. Returns response JSON."""
+        _validate_resource_id(resource_id)
+        response = self.session.post(
+            f"{self.base_url}/api/{path}/{resource_id}/{action}", params=params, timeout=timeout,
+        )
+        _raise_for_status(response)
+        return response.json()
+
     def post_resource(self, path: str, body: dict, params: dict | None = None) -> str | None:
         """POST /api/{path}. Returns location-html URL if present."""
         response = self.session.post(f"{self.base_url}/api/{path}", json=body, params=params, timeout=REQUEST_TIMEOUT)

--- a/src/entropy_data_cli/commands/datacontracts.py
+++ b/src/entropy_data_cli/commands/datacontracts.py
@@ -78,6 +78,28 @@ def put_datacontract(
         handle_error(e)
 
 
+@datacontracts_app.command("test")
+def test_datacontract(
+    id: Annotated[str, typer.Argument(help="Data contract ID.")],
+    server: Annotated[Optional[str], typer.Option("--server", "-s", help="Server name to test against.")] = None,
+) -> None:
+    """Run a data contract test."""
+    import json
+
+    from entropy_data_cli.cli import get_client, handle_error
+
+    try:
+        client = get_client()
+        params = {}
+        if server:
+            params["server"] = server
+        # Data contract tests can take a long time (up to 30 minutes)
+        data = client.post_action_json(RESOURCE_PATH, id, "test", params=params, timeout=1800)
+        print(json.dumps(data, indent=2))
+    except Exception as e:
+        handle_error(e)
+
+
 @datacontracts_app.command("delete")
 def delete_datacontract(
     id: Annotated[str, typer.Argument(help="Data contract ID.")],


### PR DESCRIPTION
## Summary
- New CLI command `entropy-data datacontracts test <id> [--server <name>]`
- Calls `POST /api/datacontracts/{id}/test` (new endpoint from entropy-data PR)
- Always outputs JSON, 30-minute timeout for long-running tests
- New `post_action_json` method on `EntropyDataClient` for POST actions returning JSON

## Test plan
- [ ] Run `entropy-data datacontracts test <id>` against a configured instance
- [ ] Run `entropy-data datacontracts test <id> --server <name>` with server filter
- [ ] Verify error handling for missing data contract / unconfigured tests