### PR TITLE
fix: emit valid, unmasked machine output (json/yaml)

### DIFF
--- a/src/entropy_data/commands/connection.py
+++ b/src/entropy_data/commands/connection.py
@@ -102,11 +102,15 @@ def get_connection(
 
     fmt = output or get_output_format()
     if fmt != OutputFormat.table:
+        # JSON/YAML are machine-consumed (scripts, automation). Masking here
+        # only breaks tooling and adds no security — the key already lives in
+        # plaintext in ~/.entropy-data/config.toml. Emit the real value; the
+        # mask / --show-api-key flag governs the human `table` view only.
         payload = {
             "name": resolved_name,
             "host": conn.get("host", cfg.DEFAULT_HOST),
             "vanity_url": conn.get("vanity_url"),
-            "api_key": displayed_key,
+            "api_key": api_key_value,
             "default": is_default,
         }
         print_data(payload, fmt)

--- a/src/entropy_data/output.py
+++ b/src/entropy_data/output.py
@@ -1,6 +1,7 @@
 """Output formatting for CLI results."""
 
 import json
+import sys
 from enum import Enum
 
 import yaml
@@ -18,11 +19,27 @@ class OutputFormat(str, Enum):
 
 
 def print_data(data, fmt: OutputFormat) -> None:
-    """Print data structured as JSON or YAML."""
+    """Print data structured as JSON or YAML.
+
+    Machine formats are written straight to stdout, NOT through the Rich
+    console: Rich soft-wraps to the (80-col, non-TTY) console width and parses
+    markup, which breaks long scalar values mid-token and yields invalid YAML
+    when the output is piped or redirected to a file. ``width`` is set high so
+    PyYAML itself does not fold long strings either.
+    """
     if fmt == OutputFormat.yaml:
-        console.print(yaml.safe_dump(data, sort_keys=False, default_flow_style=False), end="")
+        sys.stdout.write(
+            yaml.safe_dump(
+                data,
+                sort_keys=False,
+                default_flow_style=False,
+                allow_unicode=True,
+                width=4096,
+            )
+        )
     else:
-        console.print_json(json.dumps(data))
+        json.dump(data, sys.stdout, indent=2)
+        sys.stdout.write("\n")
 
 
 # Column definitions per resource type: list of (header, dict_key)


### PR DESCRIPTION
## Summary
Two bugs that break scripted use of the CLI:

- **`-o yaml` produced invalid YAML.** `print_data` printed YAML through the Rich `console`, which soft-wraps to the 80-column (non-TTY) width and interprets markup. Long scalar values (e.g. ODCS descriptions) were broken mid-token, so `entropy-data datacontracts get -o yaml > file` yielded a file that no YAML parser could load (and `dbt parse` then failed on it). Machine formats are now written straight to `stdout`; the YAML `width` is raised so PyYAML itself does not fold long strings.
- **`connection get -o json/-o yaml` masked the api_key.** Scripts reading the key back (e.g. for the OpenLineage transport) received `ed_d...XXXX` and authenticated with a bogus value. Masking a machine format adds no security — the key is already plaintext in `~/.entropy-data/config.toml` — and only breaks tooling. json/yaml now return the real key; `--show-api-key` / masking applies to the human `table` view only.