### PR TITLE
Add organization custom-team-roles commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ entropy-data [--version] [--connection NAME] [--output table|json|yaml] [--debug
   api-keys        create | delete
   connectors      list | get | put | delete
   integrations    list | get | configuration | runs | runs-get | run | cancel
-  organization    get | members ... | git-credentials ...
+  organization    get | members ... | git-credentials ... | custom-team-roles ...
   settings        get-customization | put-customization | get-scim-mapping | put-scim-mapping
   events          poll
   lineage         list | submit | delete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "entropy-data"
-version = "0.3.12"
+version = "0.3.13"
 description = "CLI for Entropy Data"
 requires-python = ">=3.11"
 license = "MIT"

--- a/src/entropy_data/commands/custom_team_roles.py
+++ b/src/entropy_data/commands/custom_team_roles.py
@@ -1,0 +1,161 @@
+"""Custom team roles commands (organization-scoped)."""
+
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+
+from entropy_data.output import OutputFormat, print_resource, print_resource_list, print_success
+from entropy_data.util import read_body
+
+custom_team_roles_app = typer.Typer(no_args_is_help=True)
+
+BASE_PATH = "organization/custom-team-roles"
+
+
+def _split_permissions(values: Optional[list[str]]) -> Optional[list[str]]:
+    """Allow `--permissions A,B --permissions C` style; flatten and trim."""
+    if not values:
+        return None
+    out: list[str] = []
+    for v in values:
+        for part in v.split(","):
+            part = part.strip()
+            if part:
+                out.append(part)
+    return out
+
+
+def _build_body(
+    name: str,
+    body_name: Optional[str],
+    description: Optional[str],
+    rank: Optional[int],
+    permissions: Optional[list[str]],
+    file: Optional[Path],
+) -> dict:
+    if file is not None:
+        body = read_body(file)
+        body.setdefault("name", body_name or name)
+        return body
+    body: dict = {"name": body_name or name}
+    if description is not None:
+        body["description"] = description
+    if rank is not None:
+        body["rank"] = rank
+    if permissions is not None:
+        body["permissions"] = permissions
+    else:
+        body["permissions"] = []
+    return body
+
+
+@custom_team_roles_app.command("list")
+def list_roles(
+    page: Annotated[int, typer.Option("--page", "-p", help="Page number (0-indexed).")] = 0,
+    output: Annotated[Optional[OutputFormat], typer.Option("--output", "-o", help="Output format.")] = None,
+) -> None:
+    """List custom team roles defined for the organization."""
+    from entropy_data.cli import get_client, get_output_format, handle_error
+
+    fmt = output or get_output_format()
+    try:
+        client = get_client()
+        data, has_next = client.list_resources(BASE_PATH, params={"p": page})
+        print_resource_list(data, "custom-team-roles", fmt, has_next_page=has_next, page=page)
+    except Exception as e:
+        handle_error(e)
+
+
+@custom_team_roles_app.command("get")
+def get_role(
+    name: Annotated[str, typer.Argument(help="Name of the custom team role.")],
+    output: Annotated[Optional[OutputFormat], typer.Option("--output", "-o", help="Output format.")] = None,
+) -> None:
+    """Get a custom team role by name."""
+    from entropy_data.cli import get_client, get_output_format, handle_error
+
+    fmt = output or get_output_format()
+    try:
+        client = get_client()
+        data = client.get_resource(BASE_PATH, name)
+        print_resource(data, "custom-team-roles", fmt)
+    except Exception as e:
+        handle_error(e)
+
+
+@custom_team_roles_app.command("put")
+def put_role(
+    name: Annotated[str, typer.Argument(help="Name of the role at this URL. Pass a different --name to rename.")],
+    file: Annotated[
+        Optional[Path],
+        typer.Option("--file", "-f", help="JSON or YAML file with the body (use - for stdin)."),
+    ] = None,
+    body_name: Annotated[
+        Optional[str],
+        typer.Option(
+            "--name",
+            help="Name to set on the role. Must equal the path name on create. Set to a different value to rename an existing role.",
+        ),
+    ] = None,
+    description: Annotated[Optional[str], typer.Option("--description", help="Optional description.")] = None,
+    rank: Annotated[
+        Optional[int],
+        typer.Option("--rank", help="Display order — lower ranks appear first."),
+    ] = None,
+    permissions: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--permissions",
+            help="Comma-separated or repeated TeamPermission values (e.g. ACCESS_APPROVE,ACCESS_EDIT).",
+        ),
+    ] = None,
+) -> None:
+    """Create, update, or rename a custom team role.
+
+    Resolution by path `name`:
+      - No role at path, body name matches → create.
+      - Role at path, body name matches → update in place.
+      - Role at path, body name differs → rename (rejected if the path name is still
+        assigned to a team member, or if the new name already exists).
+      - No role at path, body name differs → 400.
+    """
+    from entropy_data.cli import get_client, handle_error
+
+    body = _build_body(
+        name=name,
+        body_name=body_name,
+        description=description,
+        rank=rank,
+        permissions=_split_permissions(permissions),
+        file=file,
+    )
+
+    try:
+        client = get_client()
+        client.put_resource(BASE_PATH, name, body)
+        target = body.get("name") or name
+        if target != name:
+            print_success(f"Custom team role '{name}' renamed to '{target}'.")
+        else:
+            print_success(f"Custom team role '{target}' saved.")
+    except Exception as e:
+        handle_error(e)
+
+
+@custom_team_roles_app.command("delete")
+def delete_role(
+    name: Annotated[str, typer.Argument(help="Name of the custom team role to delete.")],
+) -> None:
+    """Delete a custom team role.
+
+    Rejected with 409 when the role is still assigned to any team member.
+    """
+    from entropy_data.cli import get_client, handle_error
+
+    try:
+        client = get_client()
+        client.delete_resource(BASE_PATH, name)
+        print_success(f"Custom team role '{name}' deleted.")
+    except Exception as e:
+        handle_error(e)

--- a/src/entropy_data/commands/organization.py
+++ b/src/entropy_data/commands/organization.py
@@ -88,10 +88,17 @@ def get_member(
 organization_app.add_typer(members_app, name="members", help="Manage organization members.")
 
 
+from entropy_data.commands.custom_team_roles import custom_team_roles_app  # noqa: E402
 from entropy_data.commands.git_credentials import make_git_credentials_app  # noqa: E402
 
 organization_app.add_typer(
     make_git_credentials_app("organization"),
     name="git-credentials",
     help="Manage organization-level git credentials.",
+)
+
+organization_app.add_typer(
+    custom_team_roles_app,
+    name="custom-team-roles",
+    help="Manage organization-level custom team roles.",
 )

--- a/src/entropy_data/output.py
+++ b/src/entropy_data/output.py
@@ -73,6 +73,12 @@ RESOURCE_COLUMNS: dict[str, list[tuple[str, str]]] = {
     ],
     "tags": [("ID", "id"), ("Owner", "info.owner"), ("Description", "info.description")],
     "organization-members": [("Email", "emailAddress"), ("User ID", "userId"), ("Role", "role")],
+    "custom-team-roles": [
+        ("Name", "name"),
+        ("Rank", "rank"),
+        ("Permissions", "permissions"),
+        ("Description", "description"),
+    ],
     "connectors": [("ID", "id"), ("Type", "info.type"), ("Version", "info.connectorVersion")],
     "integrations": [
         ("ID", "externalId"),

--- a/tests/commands/test_custom_team_roles.py
+++ b/tests/commands/test_custom_team_roles.py
@@ -1,0 +1,235 @@
+"""Tests for organization custom-team-roles commands."""
+
+import json
+
+import responses
+from typer.testing import CliRunner
+
+import entropy_data.config as cfg
+from entropy_data.cli import app
+
+runner = CliRunner()
+BASE_URL = "https://api.entropy-data.com"
+COLLECTION_URL = f"{BASE_URL}/api/organization/custom-team-roles"
+
+APPROVER = {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "name": "Approver",
+    "description": "Approves access",
+    "rank": 10,
+    "permissions": ["ACCESS_APPROVE", "ACCESS_EDIT"],
+    "createdAt": "2026-06-10T00:00:00Z",
+    "createdBy": "api-key:abc",
+    "updatedAt": "2026-06-10T00:00:00Z",
+    "updatedBy": "api-key:abc",
+}
+
+
+def _setup(monkeypatch, tmp_path):
+    monkeypatch.setattr(cfg, "CONFIG_FILE", tmp_path / "config.toml")
+    monkeypatch.setenv("ENTROPY_DATA_API_KEY", "test-key")
+
+
+@responses.activate
+def test_list_table(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(responses.GET, COLLECTION_URL, json=[APPROVER], status=200)
+    result = runner.invoke(app, ["organization", "custom-team-roles", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Approver" in result.output
+    assert "ACCESS_APPROVE" in result.output
+
+
+@responses.activate
+def test_list_json(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(responses.GET, COLLECTION_URL, json=[APPROVER], status=200)
+    result = runner.invoke(app, ["organization", "custom-team-roles", "list", "--output", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 1
+    assert data[0]["name"] == "Approver"
+    assert data[0]["permissions"] == ["ACCESS_APPROVE", "ACCESS_EDIT"]
+
+
+@responses.activate
+def test_list_paging(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(responses.GET, COLLECTION_URL, json=[APPROVER], status=200)
+    result = runner.invoke(app, ["organization", "custom-team-roles", "list", "--page", "2"])
+    assert result.exit_code == 0
+    assert "p=2" in responses.calls[0].request.url
+
+
+@responses.activate
+def test_get(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(responses.GET, f"{COLLECTION_URL}/Approver", json=APPROVER, status=200)
+    result = runner.invoke(app, ["organization", "custom-team-roles", "get", "Approver", "--output", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["name"] == "Approver"
+    assert data["rank"] == 10
+
+
+@responses.activate
+def test_get_not_found(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(
+        responses.GET,
+        f"{COLLECTION_URL}/Ghost",
+        json={
+            "type": "about:blank",
+            "title": "Not Found",
+            "status": 404,
+            "detail": "Custom team role 'Ghost' not found",
+        },
+        status=404,
+    )
+    result = runner.invoke(app, ["organization", "custom-team-roles", "get", "Ghost"])
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+@responses.activate
+def test_put_create_from_options(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(responses.PUT, f"{COLLECTION_URL}/Approver", json=APPROVER, status=201)
+    result = runner.invoke(
+        app,
+        [
+            "organization",
+            "custom-team-roles",
+            "put",
+            "Approver",
+            "--description",
+            "Approves access",
+            "--rank",
+            "10",
+            "--permissions",
+            "ACCESS_APPROVE,ACCESS_EDIT",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "saved" in result.output.lower()
+    body = json.loads(responses.calls[0].request.body)
+    assert body["name"] == "Approver"
+    assert body["rank"] == 10
+    assert body["permissions"] == ["ACCESS_APPROVE", "ACCESS_EDIT"]
+
+
+@responses.activate
+def test_put_create_from_file(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    body_file = tmp_path / "role.json"
+    body_file.write_text(json.dumps({"name": "Approver", "rank": 10, "permissions": ["ACCESS_APPROVE"]}))
+    responses.add(responses.PUT, f"{COLLECTION_URL}/Approver", json=APPROVER, status=201)
+    result = runner.invoke(app, ["organization", "custom-team-roles", "put", "Approver", "--file", str(body_file)])
+    assert result.exit_code == 0, result.output
+    body = json.loads(responses.calls[0].request.body)
+    assert body["name"] == "Approver"
+    assert body["permissions"] == ["ACCESS_APPROVE"]
+
+
+@responses.activate
+def test_put_rename(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    renamed = {**APPROVER, "name": "FinalApprover"}
+    responses.add(responses.PUT, f"{COLLECTION_URL}/Approver", json=renamed, status=200)
+    result = runner.invoke(
+        app,
+        [
+            "organization",
+            "custom-team-roles",
+            "put",
+            "Approver",
+            "--name",
+            "FinalApprover",
+            "--permissions",
+            "ACCESS_APPROVE",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "renamed" in result.output.lower()
+    assert "FinalApprover" in result.output
+    body = json.loads(responses.calls[0].request.body)
+    assert body["name"] == "FinalApprover"
+
+
+@responses.activate
+def test_put_permissions_repeated_and_comma_combined(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(responses.PUT, f"{COLLECTION_URL}/Approver", json=APPROVER, status=201)
+    result = runner.invoke(
+        app,
+        [
+            "organization",
+            "custom-team-roles",
+            "put",
+            "Approver",
+            "--permissions",
+            "ACCESS_APPROVE,ACCESS_EDIT",
+            "--permissions",
+            "ACCESS_REQUEST",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = json.loads(responses.calls[0].request.body)
+    assert body["permissions"] == ["ACCESS_APPROVE", "ACCESS_EDIT", "ACCESS_REQUEST"]
+
+
+@responses.activate
+def test_put_rejects_invalid_permission(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(
+        responses.PUT,
+        f"{COLLECTION_URL}/BadRole",
+        json={
+            "type": "about:blank",
+            "title": "Bad Request",
+            "status": 400,
+            "detail": "Unknown permission(s): NOT_A_THING. Valid permissions: ...",
+        },
+        status=400,
+    )
+    result = runner.invoke(
+        app,
+        [
+            "organization",
+            "custom-team-roles",
+            "put",
+            "BadRole",
+            "--permissions",
+            "NOT_A_THING",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "NOT_A_THING" in result.output
+
+
+@responses.activate
+def test_delete(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(responses.DELETE, f"{COLLECTION_URL}/Approver", status=204)
+    result = runner.invoke(app, ["organization", "custom-team-roles", "delete", "Approver"])
+    assert result.exit_code == 0, result.output
+    assert "deleted" in result.output.lower()
+
+
+@responses.activate
+def test_delete_in_use_shows_conflict_message(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    responses.add(
+        responses.DELETE,
+        f"{COLLECTION_URL}/Approver",
+        json={
+            "type": "about:blank",
+            "title": "Conflict",
+            "status": 409,
+            "detail": "Custom team role 'Approver' is assigned to 1 team member(s). Reassign or remove them before deleting or renaming.",
+        },
+        status=409,
+    )
+    result = runner.invoke(app, ["organization", "custom-team-roles", "delete", "Approver"])
+    assert result.exit_code != 0
+    assert "assigned to 1 team member" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -143,7 +143,7 @@ wheels = [
 
 [[package]]
 name = "entropy-data"
-version = "0.3.12"
+version = "0.3.13"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Adds `entropy-data organization custom-team-roles list | get | put | delete`, wrapping the new `/api/organization/custom-team-roles` REST endpoints.
- `put` is the upsert verb. A `--name` equal to the path name creates or updates in place; a `--name` different from the path name renames the existing role. The API enforces the 409 guards (old name still in use / new name already taken) so the CLI just relays them through `handle_error`.
- Permissions accept both comma-separated and repeated `--permissions` forms; `--file` (JSON/YAML, `-` for stdin) is the escape hatch for full-body input.
- Bumps version to `0.3.13` and adds the new group to the README command table.