### PR TITLE
Confirm the host explicitly in interactive connection add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- `entropy-data connection add` now also prompts for the host when the call is interactive (no `--api-key` given), defaulting to `https://api.entropy-data.com` when confirmed with enter. Previously the host silently fell back to the cloud default in the interactive flow, making it easy to store a connection to the wrong instance (e.g. when targeting a local Community Edition). Scripted calls that pass `--api-key` are unaffected and keep defaulting silently.
+
 ## [0.3.12]
 
 - Add `entropy-data integrations runs-get <integration> <run-id>` to fetch a single ingestion run by id. Wraps `GET /api/integrations/{ingestionId}/runs/{ingestionRunId}`, the last documented API endpoint not yet exposed by the CLI. Like the other `integrations` commands, the integration argument accepts an `externalId`, display `name`, or UUID.

--- a/src/entropy_data/commands/connection.py
+++ b/src/entropy_data/commands/connection.py
@@ -74,9 +74,7 @@ def get_connection(
         bool,
         typer.Option("--show-api-key", help="Print the API key in clear text (default: masked)."),
     ] = False,
-    output: Annotated[
-        Optional[OutputFormat], typer.Option("--output", "-o", help="Output format.")
-    ] = None,
+    output: Annotated[Optional[OutputFormat], typer.Option("--output", "-o", help="Output format.")] = None,
 ) -> None:
     """Get details of a named connection (use --show-api-key to reveal the key)."""
     from entropy_data.cli import get_output_format
@@ -86,10 +84,7 @@ def get_connection(
 
     resolved_name = name or config.get("default_connection_name")
     if resolved_name is None:
-        print_error(
-            "No connection specified and no default set. "
-            "Run: entropy-data connection set-default <name>"
-        )
+        print_error("No connection specified and no default set. Run: entropy-data connection set-default <name>")
         raise typer.Exit(1)
     if resolved_name not in connections:
         print_error(f"Connection '{resolved_name}' not found.")
@@ -132,10 +127,10 @@ def get_connection(
 @connection_app.command("add")
 def add_connection(
     name: Annotated[str, typer.Argument(help="Connection name.")],
-    api_key: Annotated[str, typer.Option("--api-key", prompt="API key", help="The API key.")] = None,
+    api_key: Annotated[Optional[str], typer.Option("--api-key", help="The API key.")] = None,
     host: Annotated[
-        str, typer.Option("--host", prompt="Host", prompt_required=False, help="API host URL.")
-    ] = cfg.DEFAULT_HOST,
+        Optional[str], typer.Option("--host", help=f"API host URL. Defaults to {cfg.DEFAULT_HOST}.")
+    ] = None,
 ) -> None:
     """Add or update a named connection.
 
@@ -143,6 +138,14 @@ def add_connection(
     provided API key. Fetching is best-effort: older servers or network errors
     fall back to no vanity URL on the stored connection.
     """
+    if api_key is None:
+        # No API key on the command line: the call is interactive anyway, so also
+        # confirm the host explicitly instead of silently storing the cloud default.
+        api_key = typer.prompt("API key")
+        if host is None:
+            host = typer.prompt("Host", default=cfg.DEFAULT_HOST)
+    if host is None:
+        host = cfg.DEFAULT_HOST
     try:
         vanity_url = _fetch_vanity_url(api_key, host)
         if vanity_url:

--- a/tests/commands/test_connection.py
+++ b/tests/commands/test_connection.py
@@ -37,6 +37,58 @@ def test_connection_add_and_list(tmp_path, monkeypatch):
 
 
 @responses.activate
+def test_connection_add_with_api_key_does_not_prompt_for_host(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cfg, "CONFIG_FILE", tmp_path / "config.toml")
+    # scripted call: API key given, host omitted — silently defaults, no prompt
+    result = runner.invoke(app, ["connection", "add", "prod", "--api-key", "mykey123456"])
+    assert result.exit_code == 0
+    assert "saved" in result.output
+    assert "Host" not in result.output
+    result = runner.invoke(app, ["connection", "get", "prod", "-o", "json"])
+    assert json.loads(result.output)["host"] == cfg.DEFAULT_HOST
+
+
+@responses.activate
+def test_connection_add_interactive_confirms_host_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cfg, "CONFIG_FILE", tmp_path / "config.toml")
+    # interactive call (no API key): prompts for key AND host; enter accepts the cloud default
+    result = runner.invoke(app, ["connection", "add", "prod"], input="mykey123456\n\n")
+    assert result.exit_code == 0
+    assert "saved" in result.output
+    assert f"Host [{cfg.DEFAULT_HOST}]" in result.output
+    result = runner.invoke(app, ["connection", "get", "prod", "-o", "json"])
+    assert json.loads(result.output)["host"] == cfg.DEFAULT_HOST
+
+
+@responses.activate
+def test_connection_add_interactive_overwrites_host(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cfg, "CONFIG_FILE", tmp_path / "config.toml")
+    result = runner.invoke(app, ["connection", "add", "local"], input="mykey123456\nhttp://localhost:8081\n")
+    assert result.exit_code == 0
+    assert "saved" in result.output
+    result = runner.invoke(app, ["connection", "get", "local", "-o", "json"])
+    assert json.loads(result.output)["host"] == "http://localhost:8081"
+
+
+@responses.activate
+def test_connection_add_interactive_with_host_flag_does_not_prompt_for_host(tmp_path, monkeypatch):
+    monkeypatch.setattr(cfg, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(cfg, "CONFIG_FILE", tmp_path / "config.toml")
+    # host given explicitly: only the API key is prompted
+    result = runner.invoke(
+        app, ["connection", "add", "local", "--host", "http://localhost:8081"], input="mykey123456\n"
+    )
+    assert result.exit_code == 0
+    assert "saved" in result.output
+    assert "Host" not in result.output
+    result = runner.invoke(app, ["connection", "get", "local", "-o", "json"])
+    assert json.loads(result.output)["host"] == "http://localhost:8081"
+
+
+@responses.activate
 def test_connection_add_fetches_vanity_url(tmp_path, monkeypatch):
     monkeypatch.setattr(cfg, "CONFIG_DIR", tmp_path)
     monkeypatch.setattr(cfg, "CONFIG_FILE", tmp_path / "config.toml")


### PR DESCRIPTION
## What

`entropy-data connection add <name>` without `--api-key` is an interactive flow — it prompts for the API key. Previously the host was silently stored as the cloud default in that flow, making it easy to save a connection pointing at the wrong instance (e.g. when targeting a local Community Edition). Now the interactive flow also confirms the host explicitly:

```
$ entropy-data connection add local
API key: ed_...
Host [https://api.entropy-data.com]: http://localhost:8081
Connection 'local' saved.
```

Pressing enter keeps the cloud default; typing a URL overwrites it.

## Compatibility

Scripted calls are unaffected: `connection add <name> --api-key ed_x` still defaults the host silently without prompting, so existing automation keeps working. Passing `--host` explicitly also never prompts for it.

## How

The conditional prompting (host prompt only when the call is already interactive) cannot be expressed with Typer's option-level `prompt=` attributes, so both options are plain now and the prompting happens in the command body, keyed off `api_key is None`.

## Tests

Four new/updated cases: scripted call does not prompt, interactive enter keeps the default, interactive input overwrites the host, and `--host` with prompted API key skips the host prompt. Full suite: 226 passed, ruff check/format clean.